### PR TITLE
Unpin enforcer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,19 +83,8 @@
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Stephan Saalfeld</license.copyrightOwners>
 
-		<scijava.jvm.build.version>[1.8.0-101,11]</scijava.jvm.build.version>
-
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-
-		<!-- TODO remove when pom-scijava-base is updated -->
-		<scijava.jvm.version>8</scijava.jvm.version>
-		<scijava.jvm.build.version>[1.8.0-101,)</scijava.jvm.build.version>
-
-		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
-		<jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
-
-		<n5.version>3.1.2</n5.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
And in particular, unpin the maven-enforcer-plugin, so that it can
roll forward without problems when the next pom-scijava release lands.